### PR TITLE
SCALRCORE-33689: Remove Deprecated set-output From Workflows

### DIFF
--- a/.github/workflows/check_partials.yml
+++ b/.github/workflows/check_partials.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Output changed files
       id: changes
       run: >-
-        echo "::set-output name=md::$(
+        echo "md=$(
           git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} |
           grep .md$ |
           xargs
-        )"
+        )" >> $GITHUB_OUTPUT
 
     - name: Check for invalid partials
       run: |


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
